### PR TITLE
Avoid hiding elements with a class matching "commentable".

### DIFF
--- a/chrome/content/application.css
+++ b/chrome/content/application.css
@@ -1,5 +1,5 @@
 body[CommentBlocker] [id*="comment"], body[CommentBlocker] [id*="Comment"], body[CommentBlocker] [id*="COMMENT"],
-body[CommentBlocker] [class*="comment"], body[CommentBlocker] [class*="Comment"], body[CommentBlocker] [class*="COMMENT"],
+body[CommentBlocker] [class*="comment"]:not([class*="commentable"]), body[CommentBlocker] [class*="Comment"]:not([class*="Commentable"]), body[CommentBlocker] [class*="COMMENT"]:not([class*="COMMENTABLE"]),
 body[CommentBlocker] [name*="comment"], body[CommentBlocker] [name*="Comment"], body[CommentBlocker] [name*="COMMENT"],
 body[CommentBlocker] #disqus_thread {
     display:none !important;

--- a/chrome/content/application.js
+++ b/chrome/content/application.js
@@ -83,7 +83,7 @@ var CommentBlocker = {
         hasComments: function(elem) {
             return elem.querySelector(
                 '[id*="comment"], [id*="Comment"], [id*="COMMENT"], ' +
-                '[class*="comment"], [class*="Comment"], [class*="COMMENT"], ' +
+                '[class*="comment"]:not([class*="commentable"]), [class*="Comment"]:not([class*="Commentable"]), [class*="COMMENT"]:not([class*="COMMENTABLE"]), ' +
                 '[name*="comment"], [name*="Comment"], [name*="COMMENT"], ' +
                 '#disqus_thread'
             ) != null;


### PR DESCRIPTION
This was overblocking elements on The Guardian's homepage, see http://www.theguardian.com/international and a [review from July](https://addons.mozilla.org/en-us/firefox/addon/commentblocker/reviews/727882/).

